### PR TITLE
Make library Deno compatible

### DIFF
--- a/src/BencodeDecoder.ts
+++ b/src/BencodeDecoder.ts
@@ -1,4 +1,5 @@
 import { BencodeDictionary, BencodeList, BencodeTypes, FLAG, IBencodecOptions } from './types';
+import { Buffer } from 'node:buffer';
 
 export class BencodeDecoder {
 


### PR DESCRIPTION
I tested this change with the current file, after building:

``` javascript
import * as lib from './lib/index.js';

console.log(lib.encode("hello").toString());

console.log(lib.decode("5:hello").toString());
```

and with the command line:

```
$ deno run -A --unstable-detect-cjs ./denoTest.js
5:hello
hello
```